### PR TITLE
Import upstream commits concerning platform/prebuilts/abi-dumps

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -1236,7 +1236,7 @@
   <project path="pdk" name="platform/pdk" groups="pdk" />
   <project path="platform_testing" name="platform/platform_testing" groups="pdk-fs,pdk-cw-fs,cts,sysui-studio" />
   <project path="prebuilts/abi-dumps/ndk" name="platform/prebuilts/abi-dumps/ndk" groups="pdk-cw-fs,pdk-fs" clone-depth="1" />
-  <project path="prebuilts/abi-dumps/platform" name="platform_prebuilts_abi-dumps_platform" groups="pdk-cw-fs,pdk-fs" clone-depth="1" remote="grapheneos" />
+  <project path="prebuilts/abi-dumps/platform" name="platform/prebuilts/abi-dumps/platform" groups="pdk-cw-fs,pdk-fs" clone-depth="1" />
   <project path="prebuilts/abi-dumps/vndk" name="platform/prebuilts/abi-dumps/vndk" groups="pdk-cw-fs,pdk-fs" clone-depth="1" />
   <project path="prebuilts/android-emulator" name="platform/prebuilts/android-emulator" groups="pdk-fs" clone-depth="1" />
   <project path="prebuilts/asuite" name="platform/prebuilts/asuite" groups="pdk" clone-depth="1" />

--- a/default.xml
+++ b/default.xml
@@ -1237,7 +1237,7 @@
   <project path="platform_testing" name="platform/platform_testing" groups="pdk-fs,pdk-cw-fs,cts,sysui-studio" />
   <project path="prebuilts/abi-dumps/ndk" name="platform/prebuilts/abi-dumps/ndk" groups="pdk-cw-fs,pdk-fs" clone-depth="1" />
   <project path="prebuilts/abi-dumps/platform" name="platform_prebuilts_abi-dumps_platform" groups="pdk-cw-fs,pdk-fs" clone-depth="1" remote="grapheneos" />
-  <project path="prebuilts/abi-dumps/vndk" name="platform_prebuilts_abi-dumps_vndk" groups="pdk-cw-fs,pdk-fs" clone-depth="1" remote="grapheneos" />
+  <project path="prebuilts/abi-dumps/vndk" name="platform/prebuilts/abi-dumps/vndk" groups="pdk-cw-fs,pdk-fs" clone-depth="1" />
   <project path="prebuilts/android-emulator" name="platform/prebuilts/android-emulator" groups="pdk-fs" clone-depth="1" />
   <project path="prebuilts/asuite" name="platform/prebuilts/asuite" groups="pdk" clone-depth="1" />
   <project path="prebuilts/bazel/common" name="platform/prebuilts/bazel/common" groups="pdk" clone-depth="1" />


### PR DESCRIPTION
Upstream forks of platform/prebuilts/abi-dumps are no longer used; adhere to upstream changes